### PR TITLE
Fix error when closing and retrying transSslServer

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -414,8 +414,8 @@ module.exports.createProxyServer = function (opts) {
             if (e.code == 'EADDRINUSE') {
                 console.log('Address in use, retrying...');
                 setTimeout(function () {
-                  server.close();
-                  server.listen(opts['transSslPort'], hostname);
+                  transSslServer.close();
+                  transSslServer.listen(opts['transSslPort'], hostname);
                 }, 1000);
             } else {
                 emitter.emit('error', e, 'transSslError');


### PR DESCRIPTION
Currently we can hit a case where `server.close()` is called, but `server` is never defined. Looks like we want `transSslServer.close`.
